### PR TITLE
restricted folders non-normative note

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -554,6 +554,43 @@ these steps:
 
 </div>
 
+### Security Considerations: Restricted Folders
+
+*This section is non-normative.*
+
+This API could be used by websites to access more files than the users intended. As a mitigation,
+an implementor can choose to diminish the potential damage caused by this API by blocking access
+to certain paths.
+
+These paths will vary depending on the target platform. For instance, here are some possible paths
+to be excluded, per platform:
+
+#### Common Directories to all Platforms
+* Home Root Directory
+* Desktop Root Directory
+* Document Root Directory
+* Downloads Root Directory
+* Browser's Directory Tree
+* Browser's profile Directory Tree
+* "HOME_DIR/.ssh" Directory Tree
+* "HOME_DIR/.gnupg" Directory Tree
+
+#### Windows
+* "C:\Program Files" variant Directory Trees
+* "C:\Windows" Directory Tree
+* All AppData Directory Trees
+
+#### Linux
+* /dev/*
+* /sys/*
+* /proc/*
+* /.config/*
+* /.dbus/*
+
+#### Mac OS X
+* App Data Directory Tree
+* $HOME/Library/*
+
 # Accessing special filesystems # {#special-filesystems}
 
 ## The {{FileSystemDirectoryHandle/getSystemDirectory()}} method ## {#api-getsystemdirectory}


### PR DESCRIPTION
This adds a non-normative note for implementors to consider when implementing Native File System access.

This describes the suggestion to block certain folders to diminish the potential damage caused by native file access.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/oyiptong/native-file-system/pull/95.html" title="Last updated on Sep 26, 2019, 8:37 PM UTC (735db09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/95/7c4169b...oyiptong:735db09.html" title="Last updated on Sep 26, 2019, 8:37 PM UTC (735db09)">Diff</a>