### PR TITLE
Change ChooseFileSystemEntriesType to be lowercase, dash-delimited.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -483,7 +483,7 @@ steps:
 ## The {{Window/chooseFileSystemEntries()}} method ## {#api-choosefilesystementries}
 
 <xmp class=idl>
-enum ChooseFileSystemEntriesType { "openFile", "saveFile", "openDirectory" };
+enum ChooseFileSystemEntriesType { "open-file", "save-file", "open-directory" };
 
 dictionary ChooseFileSystemEntriesOptionsAccepts {
   USVString description;
@@ -492,7 +492,7 @@ dictionary ChooseFileSystemEntriesOptionsAccepts {
 };
 
 dictionary ChooseFileSystemEntriesOptions {
-    ChooseFileSystemEntriesType type = "openFile";
+    ChooseFileSystemEntriesType type = "open-file";
     boolean multiple = false;
     sequence<ChooseFileSystemEntriesOptionsAccepts> accepts;
     boolean excludeAcceptAllOption = false;
@@ -514,12 +514,12 @@ partial interface Window {
 
      |options|.{{ChooseFileSystemEntriesOptions/type}} specifies the type of the entry the website
      wants the user to pick.
-     When set to {{ChooseFileSystemEntriesType/"openFile"}} (the default), the user can select only
+     When set to {{ChooseFileSystemEntriesType/"open-file"}} (the default), the user can select only
      existing files.
-     When set to {{ChooseFileSystemEntriesType/"saveFile"}} the dialog will additionally let the
+     When set to {{ChooseFileSystemEntriesType/"save-file"}} the dialog will additionally let the
      user select files that don't yet exist, and if the user selects a file that does exist already,
      its contents will be cleared before the handle is returned to the website.
-     Finally when set to {{ChooseFileSystemEntriesType/"openDirectory"}}, the dialog will let the
+     Finally when set to {{ChooseFileSystemEntriesType/"open-directory"}}, the dialog will let the
      user select directories instead of files.
 
      If |options|.{{ChooseFileSystemEntriesOptions/multiple}} is false (or absent) the user can


### PR DESCRIPTION
This fixes #90.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/pull/104.html" title="Last updated on Nov 1, 2019, 9:01 PM UTC (46776b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/104/a3c85ef...46776b0.html" title="Last updated on Nov 1, 2019, 9:01 PM UTC (46776b0)">Diff</a>