### PR TITLE
Add opaque origin checks to API entry points.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -550,6 +550,20 @@ partial interface Window {
 The <dfn method for=Window>chooseFileSystemEntries(|options|)</dfn> method, when invoked, must run
 these steps:
 
+1. Let |environment| be the [=current settings object=].
+
+1. If |environment|'s [=environment settings object/origin=] is an [=opaque origin=],
+   return [=a promise rejected with=] a {{SecurityError}}.
+
+1. Let |browsing context| be |environment|'s [=responsible browsing context=].
+
+1. Let |top-level context| be |browsing context|'s [=top-level browsing context=].
+
+1. If |environment|'s [=environment settings object/origin=] is not [=same origin=] with |browsing context|'s [=top-level browsing context=]'s [=active document=]'s [=relevant settings object=]'s [=environment settings object/origin=],
+   return [=a promise rejected with=] a {{SecurityError}}.
+
+   Issue: There must be a better way to express this "no third-party iframes" constraint.
+
 1. TODO
 
 </div>
@@ -586,6 +600,11 @@ than on FileSystemDirectoryHandle.
 <div algorithm>
 The <dfn method for=FileSystemDirectoryHandle>getSystemDirectory(|options|)</dfn> method, when
 invoked, must run these steps:
+
+1. Let |environment| be the [=current settings object=].
+
+1. If |environment|'s [=environment settings object/origin=] is an [=opaque origin=],
+   return [=a promise rejected with=] a {{SecurityError}}.
 
 1. TODO
 

--- a/index.bs
+++ b/index.bs
@@ -559,7 +559,7 @@ these steps:
 
 1. Let |top-level context| be |browsing context|'s [=top-level browsing context=].
 
-1. If |environment|'s [=environment settings object/origin=] is not [=same origin=] with |browsing context|'s [=top-level browsing context=]'s [=active document=]'s [=relevant settings object=]'s [=environment settings object/origin=],
+1. If |environment|'s [=environment settings object/origin=] is not [=same origin=] with |browsing context|'s [=top-level browsing context=]'s [=active document=]'s  [=/origin=],
    return [=a promise rejected with=] a {{SecurityError}}.
 
    Issue: There must be a better way to express this "no third-party iframes" constraint.


### PR DESCRIPTION
Also adds a check for first-party-context only to the
chooseFileSystemEntries API.

Fixes #77


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/pull/105.html" title="Last updated on Nov 11, 2019, 10:24 PM UTC (6f4d4c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/105/c176b4f...6f4d4c8.html" title="Last updated on Nov 11, 2019, 10:24 PM UTC (6f4d4c8)">Diff</a>