### PR TITLE
Editorial: give [[spec]] links more readable text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Title: Native File System
 Shortname: native-file-system
 Abstract: This document defines a web platform API that lets websites gain write access to the
-  native file system. It builds on [[FILE-API]], but adds lots of new functionality on top.
+  native file system. It builds on [[FILE-API|File API]], but adds lots of new functionality on top.
 Status: CG-DRAFT
 ED: https://wicg.github.io/native-file-system/
 Level: 1
@@ -42,8 +42,9 @@ spec:fetch; type:interface; text:ReadableStream
 
 TODO
 
-This provides similar functionality as earlier drafts of the [[file-system-api]] as well as the
-[[entries-api]], but with a more modern API.
+This provides similar functionality as earlier drafts of the
+[[file-system-api|File API: Directories and System]] as well as the
+[[entries-api|File and Directory Entries API]], but with a more modern API.
 
 # Files and Directories # {#files-and-directories}
 


### PR DESCRIPTION
https://tabatkins.github.io/bikeshed/#biblio-autolink

The automatic [spec] style is appropriate for trailing references like
[RFC2119], less so for links in the middle of prose.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/native-file-system/pull/110.html" title="Last updated on Nov 20, 2019, 10:23 AM UTC (9f05cf9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/110/533b736...foolip:9f05cf9.html" title="Last updated on Nov 20, 2019, 10:23 AM UTC (9f05cf9)">Diff</a>