### PR TITLE
Editorial: avoid use of "iff" in domintro text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -108,10 +108,10 @@ Their [=deserialization steps=], given |serialized| and |value| are:
 
 <div class="note domintro">
   : |handle| . {{FileSystemHandle/isFile}}
-  :: Returns true iff |handle| is a {{FileSystemFileHandle}}.
+  :: Returns true if |handle| is a {{FileSystemFileHandle}}.
 
   : |handle| . {{FileSystemHandle/isDirectory}}
-  :: Returns true iff |handle| is a {{FileSystemDirectoryHandle}}.
+  :: Returns true if |handle| is a {{FileSystemDirectoryHandle}}.
 
   : |handle| . {{FileSystemHandle/name}}
   :: Returns the [=entry/name=] of the entry represented by |handle|.


### PR DESCRIPTION
This text does not need to be entirely precise, and "iff" would look
like a typo to someone not familiar with the abbreviation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/native-file-system/pull/118.html" title="Last updated on Nov 20, 2019, 11:13 AM UTC (ca74bca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/118/533b736...foolip:ca74bca.html" title="Last updated on Nov 20, 2019, 11:13 AM UTC (ca74bca)">Diff</a>