### PR TITLE
Remove reference to `inPlace` which has already been removed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -242,13 +242,6 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method, when invoked, m
      otherwise the existing file is first copied to this temporary file.
 </div>
 
-Issue: There has been some discussion around and desire for a "inPlace" mode for createWriter (where
-changes will be written to the actual underlying file as they are written to the writer, for example
-to support in-place modification of large files or things like databases). This is not currently
-implemented in Chrome. Implementing this is currently blocked on figuring out how to combine the
-desire to run malware checks with the desire to let websites make fast in-place modifications to
-existing large files.
-
 <div algorithm>
 The <dfn method for=FileSystemFileHandle>createWriter(|options|)</dfn> method, when invoked, must run these steps:
 


### PR DESCRIPTION
Removed in 5e1146ea7d0bda447dd3890f9ed041bd42987f04.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/native-file-system/pull/122.html" title="Last updated on Nov 20, 2019, 11:43 AM UTC (5331bbe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/122/533b736...foolip:5331bbe.html" title="Last updated on Nov 20, 2019, 11:43 AM UTC (5331bbe)">Diff</a>