### PR TITLE
Editorial: call 0x00s null bytes instead of zero bytes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -442,7 +442,7 @@ these steps:
 <div class="note domintro">
   : await |writer| . {{FileSystemWriter/truncate()|truncate}}(|size|)
   :: Resizes the file associated with |writer| to be |size| bytes long. If |size| is larger than
-     the current file size this pads the file with zero bytes, otherwise it truncates the file.
+     the current file size this pads the file with null bytes, otherwise it truncates the file.
 
      No changes are written to the actual file until on disk until {{FileSystemWriter/close()}}
      is called. Changes are typically written to a temporary file instead.


### PR DESCRIPTION
zero bytes sounds more like "no bytes" than is ideal.

https://encoding.spec.whatwg.org/ calls is just 0x00, but that's not
great in a non-normative domintro box.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/native-file-system/pull/129.html" title="Last updated on Nov 20, 2019, 1:00 PM UTC (a989da0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/129/533b736...foolip:a989da0.html" title="Last updated on Nov 20, 2019, 1:00 PM UTC (a989da0)">Diff</a>