### PR TITLE
fix: entries type camel case instead of dash case

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -483,7 +483,7 @@ steps:
 ## The {{Window/chooseFileSystemEntries()}} method ## {#api-choosefilesystementries}
 
 <xmp class=idl>
-enum ChooseFileSystemEntriesType { "open-file", "save-file", "open-directory" };
+enum ChooseFileSystemEntriesType { "openFile", "saveFile", "openDirectory" };
 
 dictionary ChooseFileSystemEntriesOptionsAccepts {
   USVString description;


### PR DESCRIPTION
## Description

Entries "open-file", "save-file" and "open-directory" aren't accepted by Chrome.

Instead of these, it excepts, I think, camel case entries for `ChooseFileSystemEntriesType` respectively "openFile", "saveFile" and "openDirectory".

## Stacktrace

Here the error I just faced while using "save-file":

```
export.service.ts:61 TypeError: Failed to execute 'chooseFileSystemEntries' on 'Window': The provided value 'save-file' is not a valid enum value of type ChooseFileSystemEntriesType.
    at export.service.ts:77
    at l (runtime.js:45)
    at Generator._invoke (runtime.js:264)
    at Generator.forEach.e.<computed> [as next] (runtime.js:98)
    at l (runtime.js:45)
    at t (runtime.js:137)
    at runtime.js:172
    at new Promise (<anonymous>)
    at i (runtime.js:171)
    at k._invoke (runtime.js:190)
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peterpeterparker/native-file-system/pull/142.html" title="Last updated on Dec 29, 2019, 8:41 AM UTC (13c169c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/142/533b736...peterpeterparker:13c169c.html" title="Last updated on Dec 29, 2019, 8:41 AM UTC (13c169c)">Diff</a>