### PR TITLE
Change the API for exposing the sandboxed file system.

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -28,6 +28,8 @@ In native applications, there are common file access patterns that we aim to add
 1. The files can be opened in any native or web applications concurrently
 1. Changes to the files on disk, made in any native or other web application, are accessible
 1. Access the files with the same access in future browsing sessions
+1. Create a new file in the editor
+1. Auto-save changes to the new file in a temporary location, even before the user has picked a file name/location
 
 ### Multi-file Editor
 1. Open a directory that contains many files and sub-directories, represented hierarchically
@@ -73,6 +75,13 @@ Some example applications of the API we would like to address:
 But even though we'd like to design the API to eventually enable all these use
 cases, initially we'd almost certainly be shipping a very limited API surface
 with limited capabilities.
+
+We also want to make it possible for websites to get access to some directory
+without having to first prompt the user for access. This helps to make
+it easier to write automated tests. It also enables use cases where a website
+wants to save data to disk before a user has picked a location to save to,
+without forcing the website to use a completely different storage mechanism
+with a different API for such files.
 
 ## Non-goals
 
@@ -189,7 +198,7 @@ request.onsuccess = function(e) {
 
     // Rejects if file is no longer writable, because the website no longer has
     // permission to write to it.
-    let file_writer = await ref.createWritable({createIfNotExists: true});
+    let file_writer = await ref.createWritable();
     // ... write to file_writer
 }
 ```
@@ -230,7 +239,7 @@ const file_ref = await dir_ref.getFile('foo.js');
 // Do something useful with the file.
 
 // Get a subdirectory.
-const subdir = await dir_ref.getDirectory('bla', {createIfNotExists: true});
+const subdir = await dir_ref.getDirectory('bla', {create: true});
 
 // No special API to create copies, but still possible to do so by using
 // available read and write APIs.
@@ -280,6 +289,27 @@ if (relative_path === null) {
     // Now |entry| will represent the same file on disk as |file_ref|.
     assert await entry.isSameEntry(file_ref) == true;
 }
+```
+
+To get access to a writable directory without having to ask the user for access,
+we also provide a "sandboxed" file system. Files in this directory are not
+exposed to native applications (or other web applications), but instead are
+private to the origin. Storage in this sandboxed file system is subject to
+quota restrictions and eviction measures like other web exposed storage mechanisms.
+
+```javascript
+const sandboxed_dir = await self.getSandboxedFileSystem();
+
+// The website can freely create files and directories in this directory.
+const cache_dir = await sandboxed_dir.getDirectory('cache', {create: true});
+for await (const entry of cache_dir.getEntries()) {
+    // Do something with entry.
+};
+
+const new_file = await sandboxed_dir.getFile('Untitled 1.txt', {create: true});
+const writer = await new_file.createWritable();
+writer.write("some data");
+await writer.close();
 ```
 
 And perhaps even possible to get access to certain "well-known" directories,

--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -76,12 +76,12 @@ But even though we'd like to design the API to eventually enable all these use
 cases, initially we'd almost certainly be shipping a very limited API surface
 with limited capabilities.
 
-We also want to make it possible for websites to get access to some directory
-without having to first prompt the user for access. This helps to make
-it easier to write automated tests. It also enables use cases where a website
-wants to save data to disk before a user has picked a location to save to,
-without forcing the website to use a completely different storage mechanism
-with a different API for such files.
+Additionally we want to make it possible for websites to get access to some
+directory without having to first prompt the user for access. This enables use
+cases where a website wants to save data to disk before a user has picked a
+location to save to, without forcing the website to use a completely different
+storage mechanism with a different API for such files. It also makes it easier
+to write automated tests for code using this API.
 
 ## Non-goals
 

--- a/index.bs
+++ b/index.bs
@@ -48,11 +48,19 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
 
 *This section is non-normative.*
 
-TODO
-
 This provides similar functionality as earlier drafts of the
 [[file-system-api|File API: Directories and System]] as well as the
 [[entries-api|File and Directory Entries API]], but with a more modern API.
+
+TODO explain native file system access
+
+Additionally this API also makes it possible for websites to get access to some
+directory without having to first prompt the user for access. This helps to make
+it easier to write automated tests. It also enables use cases where a website
+wants to save data to disk before a user has picked a location to save to,
+without forcing the website to use a completely different storage mechanism
+with a different API for such files. The entry point for this is the
+{{getSandboxedFileSystem()}} method.
 
 # Files and Directories # {#files-and-directories}
 
@@ -83,7 +91,7 @@ An [=/entry=]'s [=entry/parent=] is null if no such directory entry exists.
 Note: Two different [=/entries=] can represent the same file or directory on disk, in which
 case it is possible for both entries to have a different parent, or for one entry to have a
 parent while the other entry does not have a parent. Typically an entry does not have a parent
-if it was returned by {{chooseFileSystemEntries()}} or {{getSystemDirectory()}}, and an entry
+if it was returned by {{chooseFileSystemEntries()}} or {{getSandboxedFileSystem()}}, and an entry
 will have a parent in all other cases.
 
 [=/Entries=] can (but don't have to) be backed by files on the systems native file system,
@@ -136,8 +144,8 @@ Unless specified otherwise, these steps are:
 1. Assert: |parent| is not null.
 
    Note: [[#native-file-system-permissions]] overrides these steps for entries returned by
-   {{chooseFileSystemEntries()}}. Additionally [[#special-filesystem-concepts]] overrides
-   these steps for entries returned by {{FileSystemDirectoryHandle/getSystemDirectory()}}.
+   {{chooseFileSystemEntries()}}. Additionally [[#sandboxed-filesystem-concepts]] overrides
+   these steps for entries returned by {{getSandboxedFileSystem()}}.
    All other entries always have a parent.
 
 1. Return the result of running |parent|'s [=query permission steps=]
@@ -1299,9 +1307,9 @@ these steps:
 
 </div>
 
-# Accessing special file systems # {#special-filesystems}
+# Accessing the Sandboxed File System # {#sandboxed-filesystem}
 
-## Special File System Concepts ## {#special-filesystem-concepts}
+## Sandboxed File System Concepts ## {#sandboxed-filesystem-concepts}
 
 A [=bucket=] contains a <dfn>sandboxed file system root</dfn>, a [=directory entry=].
 
@@ -1324,35 +1332,24 @@ The [=sandboxed file system root=]'s [=query permission steps=] are the followin
 
 </div>
 
-## The {{FileSystemDirectoryHandle/getSystemDirectory()}} method ## {#api-getsystemdirectory}
+## The {{getSandboxedFileSystem()}} method ## {#api-getsandboxedfilesystem}
 
 <xmp class=idl>
-enum SystemDirectoryType {
-  "sandbox"
-};
-
-dictionary GetSystemDirectoryOptions {
-  required SystemDirectoryType type;
-};
-
 [SecureContext]
-partial interface FileSystemDirectoryHandle {
-  static Promise<FileSystemDirectoryHandle> getSystemDirectory(GetSystemDirectoryOptions options);
+partial interface Window {
+  Promise<FileSystemDirectoryHandle> getSandboxedFileSystem();
 };
 </xmp>
 
+Advisement: In Chrome this functionality is currently exposed as `FileSystemDirectoryHandle.getSystemDirectory({type: "sandbox"})`.
+
 <div class="note domintro">
-  : |directoryHandle| = {{FileSystemDirectoryHandle}} .
-    {{FileSystemDirectoryHandle/getSystemDirectory()|getSystemDirectory}}({
-       {{GetSystemDirectoryOptions/type}}: {{SystemDirectoryType/"sandbox"}} })
-  :: Returns the sandboxed file system.
+  : |directoryHandle| = await window . {{getSandboxedFileSystem()}}
+  :: Returns the root directory of the sandboxed file system.
 </div>
 
-Issue(27): getSystemDirectory might not be the best name. Also perhaps should be on Window rather
-than on FileSystemDirectoryHandle.
-
 <div algorithm>
-The <dfn method for=FileSystemDirectoryHandle>getSystemDirectory(|options|)</dfn> method, when
+The <dfn method for=Window>getSandboxedFileSystem()</dfn> method, when
 invoked, must run these steps:
 
 1. Let |environment| be the [=current settings object=].
@@ -1360,7 +1357,6 @@ invoked, must run these steps:
 1. If |environment|'s [=environment settings object/origin=] is an [=opaque origin=],
    return [=a promise rejected with=] a {{SecurityError}}.
 
-1. [=Assert=]: |options|.{{GetSystemDirectoryOptions/type}} is {{SystemDirectoryType/"sandbox"}}.
 1. Let |storage| be |environment|'s [=environment settings object/origin=]'s [=site storage unit=].
 1. Let |bucket| be |storage|'s [=bucket=].
 1. Return [=a promise resolved with=] a new {{FileSystemDirectoryHandle}},

--- a/index.bs
+++ b/index.bs
@@ -55,12 +55,12 @@ This provides similar functionality as earlier drafts of the
 TODO explain native file system access
 
 Additionally this API also makes it possible for websites to get access to some
-directory without having to first prompt the user for access. This helps to make
-it easier to write automated tests. It also enables use cases where a website
-wants to save data to disk before a user has picked a location to save to,
-without forcing the website to use a completely different storage mechanism
-with a different API for such files. The entry point for this is the
-{{getSandboxedFileSystem()}} method.
+directory without having to first prompt the user for access. This enables use
+cases where a website wants to save data to disk before a user has picked a
+location to save to, without forcing the website to use a completely different
+storage mechanism with a different API for such files. It also makes it easier
+to write automated tests for code using this API. The entry point for this is the
+{{getOriginPrivateDirectory()}} method.
 
 # Files and Directories # {#files-and-directories}
 
@@ -91,7 +91,7 @@ An [=/entry=]'s [=entry/parent=] is null if no such directory entry exists.
 Note: Two different [=/entries=] can represent the same file or directory on disk, in which
 case it is possible for both entries to have a different parent, or for one entry to have a
 parent while the other entry does not have a parent. Typically an entry does not have a parent
-if it was returned by {{chooseFileSystemEntries()}} or {{getSandboxedFileSystem()}}, and an entry
+if it was returned by {{chooseFileSystemEntries()}} or {{getOriginPrivateDirectory()}}, and an entry
 will have a parent in all other cases.
 
 [=/Entries=] can (but don't have to) be backed by files on the systems native file system,
@@ -145,7 +145,7 @@ Unless specified otherwise, these steps are:
 
    Note: [[#native-file-system-permissions]] overrides these steps for entries returned by
    {{chooseFileSystemEntries()}}. Additionally [[#sandboxed-filesystem-concepts]] overrides
-   these steps for entries returned by {{getSandboxedFileSystem()}}.
+   these steps for entries returned by {{getOriginPrivateDirectory()}}.
    All other entries always have a parent.
 
 1. Return the result of running |parent|'s [=query permission steps=]
@@ -1332,24 +1332,24 @@ The [=sandboxed file system root=]'s [=query permission steps=] are the followin
 
 </div>
 
-## The {{getSandboxedFileSystem()}} method ## {#api-getsandboxedfilesystem}
+## The {{getOriginPrivateDirectory()}} method ## {#api-getoriginprivatefilesystem}
 
 <xmp class=idl>
 [SecureContext]
 partial interface Window {
-  Promise<FileSystemDirectoryHandle> getSandboxedFileSystem();
+  Promise<FileSystemDirectoryHandle> getOriginPrivateDirectory();
 };
 </xmp>
 
 Advisement: In Chrome this functionality is currently exposed as `FileSystemDirectoryHandle.getSystemDirectory({type: "sandbox"})`.
 
 <div class="note domintro">
-  : |directoryHandle| = await window . {{getSandboxedFileSystem()}}
+  : |directoryHandle| = await window . {{getOriginPrivateDirectory()}}
   :: Returns the root directory of the sandboxed file system.
 </div>
 
 <div algorithm>
-The <dfn method for=Window>getSandboxedFileSystem()</dfn> method, when
+The <dfn method for=Window>getOriginPrivateDirectory()</dfn> method, when
 invoked, must run these steps:
 
 1. Let |environment| be the [=current settings object=].


### PR DESCRIPTION
Also explain what and why the sandboxed file system is.

This fixes #66 and partially addresses #27.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/pull/174.html" title="Last updated on Apr 17, 2020, 11:37 PM UTC (29a6465)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/174/827c379...29a6465.html" title="Last updated on Apr 17, 2020, 11:37 PM UTC (29a6465)">Diff</a>