### PR TITLE
Call out malware scans in writer close algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -844,7 +844,7 @@ in a [=/Realm=] |realm|, perform the following steps:
          and |stream|'s [=relevant settings object=].
       1. If |permissionStatus| is not {{PermissionState/"granted"}},
          reject |closeResult| with a {{NotAllowedError}} and abort.
-      1. Perform any [=malware scans and safe browsing checks=] the user agent might want to do.
+      1. Perform user agent-specific [=malware scans and safe browsing checks=].
          If these checks fail, [=/reject=] |closeResult| with an {{AbortError}} and abort.
       1. Set |stream|.[=[[file]]=]'s [=file entry/binary data=] to |stream|.[=[[buffer]]=].
          If that throws an exception, [=/reject=] |closeResult| with that exception and abort.

--- a/index.bs
+++ b/index.bs
@@ -844,9 +844,10 @@ in a [=/Realm=] |realm|, perform the following steps:
          and |stream|'s [=relevant settings object=].
       1. If |permissionStatus| is not {{PermissionState/"granted"}},
          reject |closeResult| with a {{NotAllowedError}} and abort.
-      1. TODO: optional UA defined security checks
+      1. Perform any [=malware scans and safe browsing checks=] the user agent might want to do.
+         If these checks fail, [=/reject=] |closeResult| with an {{AbortError}} and abort.
       1. Set |stream|.[=[[file]]=]'s [=file entry/binary data=] to |stream|.[=[[buffer]]=].
-         If that throws an exception, reject |closeResult| with that exception and abort.
+         If that throws an exception, [=/reject=] |closeResult| with that exception and abort.
 
          Note: It is expected that this atomically updates the contents of the file on disk
          being written to.
@@ -1447,12 +1448,9 @@ hand files that are already executable likely remain that way, even after the fi
 through this API). Furthermore user agents are encouraged to apply things like Mark-of-the-Web to
 files created or modified by this API.
 
-Finally, user agents are encouraged to verify the contents of files modified by this API via malware
-scans and safe browsing checks, unless some kind of external strong trust relation already exists.
+Finally, user agents are encouraged to verify the contents of files modified by this API via <dfn>malware
+scans and safe browsing checks</dfn>, unless some kind of external strong trust relation already exists.
 This of course has effects on the performance characteristics of this API.
-
-Issue(51): "Atomic writes" attempts to make it explicit what this API can and can't do, and how
-performance can be effected by safe browsing checks.
 
 ## Ransomware attacks ## {#security-ransomware}
 


### PR DESCRIPTION
This makes it clear when user agents can perform such scans, and how
failing a check will be reported.

Fixes #37


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/pull/175.html" title="Last updated on May 5, 2020, 5:07 PM UTC (5706665)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/175/de41e45...5706665.html" title="Last updated on May 5, 2020, 5:07 PM UTC (5706665)">Diff</a>