### PR TITLE
Also expose origin private directory to workers.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1383,7 +1383,7 @@ The [=sandboxed file system root=]'s [=query permission steps=] are the followin
 
 <xmp class=idl>
 [SecureContext]
-partial interface Window {
+partial interface mixin WindowOrWorkerGlobalScope {
   Promise<FileSystemDirectoryHandle> getOriginPrivateDirectory();
 };
 </xmp>
@@ -1396,7 +1396,7 @@ Advisement: In Chrome this functionality is currently exposed as `FileSystemDire
 </div>
 
 <div algorithm>
-The <dfn method for=Window>getOriginPrivateDirectory()</dfn> method, when
+The <dfn method for=WindowOrWorkerGlobalScope>getOriginPrivateDirectory()</dfn> method, when
 invoked, must run these steps:
 
 1. Let |environment| be the [=current settings object=].


### PR DESCRIPTION
This method was renamed/moved in #174, but unintentionally that change
also started limiting the API to only be available in windows. This
changes it back to also expose the origin private directory to workers.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/pull/181.html" title="Last updated on May 27, 2020, 8:39 PM UTC (46385ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/181/5e09cfb...46385ca.html" title="Last updated on May 27, 2020, 8:39 PM UTC (46385ca)">Diff</a>