### PR TITLE
Fix SVG example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1402,7 +1402,7 @@ const options = {
   <l>{{FilePickerOptions/types}}</l>: [
     {
       <l>{{FilePickerAcceptType/accept}}</l>: {
-        'image/svg+xml': ['svg'],
+        'image/svg+xml': ['svg']
       }
     },
   ],

--- a/index.bs
+++ b/index.bs
@@ -1402,7 +1402,7 @@ const options = {
   <l>{{FilePickerOptions/types}}</l>: [
     {
       <l>{{FilePickerAcceptType/accept}}</l>: {
-        'image/svg+xml': 'svg',
+        'image/svg+xml': ['svg'],
       }
     },
   ],


### PR DESCRIPTION
This example was invalid, since `accept` requires a sequence as a value.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/RReverser/native-file-system/pull/195.html" title="Last updated on Jul 2, 2020, 1:49 PM UTC (9d26090)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/195/b1b9ce2...RReverser:9d26090.html" title="Last updated on Jul 2, 2020, 1:49 PM UTC (9d26090)">Diff</a>