### PR TITLE
Rewrite the permissions logic to integrate with the permissions API.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -133,50 +133,93 @@ run the following steps:
 
 ## Permissions ## {#permissions}
 
-Issue: Figure out some way to integrate this better with the permissions API [[permissions]],
-for example by making the entry be a part of the PermissionDescriptor.
+The <dfn for=PermissionName enum-value>"file-system"</dfn> [=powerful feature=]'s
+permission-related algorithms and types are defined as follows:
+
+: [=permission descriptor type=]
+:: {{FileSystemPermissionDescriptor}}, defined as:
+  <xmp class=idl>
+  enum FileSystemPermissionMode {
+    "read",
+    "readwrite"
+  };
+
+  dictionary FileSystemPermissionDescriptor : PermissionDescriptor {
+    required FileSystemHandle handle;
+    FileSystemPermissionMode mode = "read";
+  };
+  </xmp>
+
+: [=permission state constraints=]
+:: <div algorithm="permission state constraints">
+  To determine [=permission state constraints=] for a {{FileSystemPermissionDescriptor}} |desc|,
+  run these steps:
+
+  1. Let |entry| be |desc|.{{FileSystemPermissionDescriptor/handle}}'s [=FileSystemHandle/entry=].
+  1. If |entry| represents an [=/entry=] in an [=origin private file system=],
+    this descriptor's [=permission state=] should always be {{PermissionState/"granted"}}.
+  1. Otherwise, if |entry|'s [=entry/parent=] is not null, this descriptor's [=permission state=] should be
+    equal to the [=permission state=] for a descriptor with the same {{FileSystemPermissionDescriptor/mode}},
+    and a {{FileSystemPermissionDescriptor/handle}} representing |entry|'s [=entry/parent=].
+  1. Otherwise, if |desc|.{{FileSystemPermissionDescriptor/mode}} is {{"readwrite"}}:
+    1. Let |read state| be the [=permission state=] for a descriptor
+      with the same {{FileSystemPermissionDescriptor/handle}},
+      but {{FileSystemPermissionDescriptor/mode}} = {{"read"}}.
+    1. If |read state| is not {{PermissionState/"granted"}}, this descriptor's [=permission state=]
+      should be equal to |read state|.
+
+: [=permission request algorithm=]
+:: <div algorithm="permission request algorithm">
+  Given a {{FileSystemPermissionDescriptor}} |desc| and a {{PermissionStatus}} |status|,
+  run these steps:
+
+  1. Run the [=boolean permission query algorithm=] on |desc| and |status|.
+  1. If |status|.{{PermissionStatus/state}} is not {{PermissionState/"prompt"}}, abort.
+  1. Let |settings| be |desc|.{{FileSystemPermissionDescriptor/handle}}'s [=relevant settings object=].
+  1. Let |global| be |settings|'s [=environment settings object/global object=].
+  1. If |global| is not a {{Window}}, throw a {{SecurityError}}.
+  1. If |global| does not have [=transient activation=], throw a {{SecurityError}}.
+  1. If |settings|'s [=environment settings object/origin=] is not [=same origin=] with |settings|'s [=top-level origin=],
+     throw a {{SecurityError}}.
+  1. [=Request permission to use=] |desc|.
+  1. Run the [=boolean permission query algorithm=] on |desc| and |status|.
+
+  Issue(WICG/permissions-request#2): Ideally this user activation requirement would be defined upstream.
 
 <div algorithm>
-An [=/entry=] |entry| has associated <dfn for=entry>query permission steps</dfn>,
-which take a {{FileSystemHandlePermissionDescriptor}} |descriptor|
-and an [=environment settings object=] |settings|,
-and return a {{PermissionState}}.
-Unless specified otherwise, these steps are:
-1. Let |parent| be |entry|'s [=entry/parent=].
-1. Assert: |parent| is not null.
+To <dfn lt="querying file system permission|query file system permission">query file system permission</dfn>
+given a {{FileSystemHandle}} |handle| and a {{FileSystemPermissionMode}} |mode|, run these steps:
 
-   Note: [[#native-file-system-permissions]] overrides these steps for entries returned by
-   the [=native file system handle factories=]. Additionally [[#sandboxed-filesystem]] overrides
-   these steps for entries returned by {{getOriginPrivateDirectory()}}.
-   All other entries always have a parent.
+1. Let |desc| be a {{FileSystemPermissionDescriptor}}.
+1. Set |desc|.{{PermissionDescriptor/name}} to {{"file-system"}}.
+1. Set |desc|.{{FileSystemPermissionDescriptor/handle}} to |handle|.
+1. Set |desc|.{{FileSystemPermissionDescriptor/mode}} to |mode|.
+1. Return |desc|'s [=permission state=].
 
-1. Return the result of running |parent|'s [=query permission steps=]
-   given |descriptor| and |settings|.
-
-Note: These steps return the current state synchronously, however these steps are only
-invoked from "in parallel" sections of algorithms, so this doesn't have to be implemented
-in a synchronous manner.
 </div>
 
 <div algorithm>
-An [=/entry=] |entry| also has associated <dfn for=entry>request permission steps</dfn>,
-which take a {{FileSystemHandlePermissionDescriptor}} |descriptor|
-and an [=environment settings object=] |settings|.
-Unless specified otherwise, these steps are:
-1. Let |parent| be |entry|'s [=entry/parent=].
-1. If |parent| is not null, run |parent|'s [=request permission steps=]
-   given |descriptor| and |settings|.
+To <dfn lt="requesting file system permission|request file system permission">request file system permission</dfn>
+given a {{FileSystemHandle}} |handle| and a {{FileSystemPermissionMode}} |mode|, run these steps:
 
-Note: These steps do not return anything. However as a result of executing the request
-permission steps for an entry the permission state for that entry (and other entries)
-can be updated, and the new state can be queried by executing the query permission steps.
+1. Let |desc| be a {{FileSystemPermissionDescriptor}}.
+1. Set |desc|.{{PermissionDescriptor/name}} to {{"file-system"}}.
+1. Set |desc|.{{FileSystemPermissionDescriptor/handle}} to |handle|.
+1. Set |desc|.{{FileSystemPermissionDescriptor/mode}} to |mode|.
+1. Let |status| be the result of running <a spec=permissions>create a PermissionStatus</a> for |desc|.
+1. Run the [=permission request algorithm=] for the {{"file-system"}} feature, given |desc| and |status|.
+1. Return |desc|'s [=permission state=].
+
 </div>
+
+Issue(119): Currently {{FileSystemPermissionMode}} can only be {{"read"}} or {{"readwrite"}}. In
+the future we might want to add a "write" mode as well to support write-only handles.
 
 ## The {{FileSystemHandle}} interface ## {#api-filesystemhandle}
 
 <xmp class=idl>
 dictionary FileSystemHandlePermissionDescriptor {
-  boolean writable = false;
+  FileSystemPermissionMode mode = "read";
 };
 
 enum FileSystemHandleKind {
@@ -206,7 +249,7 @@ the {{FileSystemHandle}} interface can all be associated with the same [=/entry=
 Advisement: In the Origin Trial as available in Chrome 78, these objects are not yet serializable. 
 In Chrome 82 they are.
 
-Their [=serialization steps=], given |value|, |serialized| and |forStorage| are:
+Their [=serialization steps=], given |value|, |serialized| and <var ignore>forStorage</var> are:
 
 1. Set |serialized|.\[[Origin]] to |value|'s [=relevant settings object=]'s [=environment settings object/origin=].
 1. Set |serialized|.\[[Entry]] to |value|'s [=FileSystemHandle/entry=].
@@ -245,7 +288,7 @@ associated [=FileSystemHandle/entry=].
 ### The {{FileSystemHandle/isSameEntry()}} method ### {#api-filesystemhandle-issameentry}
 
 <div class="note domintro">
-  : |same| = await |handle1| . {{FileSystemHandle/isSameEntry()|isSameEntry}}( |handle2| )
+  : <var ignore>same</var> = await |handle1| . {{FileSystemHandle/isSameEntry()|isSameEntry}}( |handle2| )
   :: Returns true if |handle1| and |handle2| represent the same file or directory.
 </div>
 
@@ -266,14 +309,10 @@ The <dfn method for=FileSystemHandle>isSameEntry(|other|)</dfn> method, when inv
 
 ### The {{FileSystemHandle/queryPermission()}} method ### {#api-filesystemhandle-querypermission}
 
-Issue(119): the currently described API here assumes a model where it is not possible to have a
-    write-only handle. I.e. it is not possible to have or request write access without also having
-    read access. There definitely are use cases for write-only handles (e.g. directory downloads),
-    so we might have to reconsider this.
-
 <div class="note domintro">
-  : |status| = await |handle| . {{FileSystemHandle/queryPermission()|queryPermission}}({ {{FileSystemHandlePermissionDescriptor/writable}} = false })
+  : |status| = await |handle| . {{FileSystemHandle/queryPermission()|queryPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : {{"read"}} })
   : |status| = await |handle| . {{FileSystemHandle/queryPermission()}}
+  : |status| = (await navigator.{{Navigator/permissions}}.{{Permissions/query()|query}}({ {{PermissionDescriptor/name}} : "file-system", {{FileSystemPermissionDescriptor/handle}} : |handle| })).{{PermissionStatus/state}}
   :: Queries the current state of the read permission of this handle. If this returns `"prompt"`
      the website will have to call {{FileSystemHandle/requestPermission()}} before any
      operations on the handle can be done. If this returns `"denied"` any operations will reject.
@@ -282,7 +321,8 @@ Issue(119): the currently described API here assumes a model where it is not pos
      their read permission state, however other than through the user revoking permission, a handle
      retrieved from IndexedDB is also likely to return `"prompt"`.
 
-  : |status| = await |handle| . {{FileSystemHandle/queryPermission()|queryPermission}}({ {{FileSystemHandlePermissionDescriptor/writable}} = true })
+  : |status| = await |handle| . {{FileSystemHandle/queryPermission()|queryPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} : {{"readwrite"}} })
+  : |status| = (await navigator.{{Navigator/permissions}}.{{Permissions/query()|query}}({ {{PermissionDescriptor/name}} : "file-system", {{FileSystemPermissionDescriptor/handle}} : |handle|, {{FileSystemPermissionDescriptor/mode}} : {{"readwrite"}}}).{{PermissionStatus/state}}
   :: Queries the current state of the write permission of this handle. If this returns `"prompt"`,
      attempting to modify the file or directory this handle represents will require user activation
      and will result in a confirmation prompt being shown to the user. However if the state of the
@@ -291,14 +331,16 @@ Issue(119): the currently described API here assumes a model where it is not pos
      attempting to read from a file or directory.
 </div>
 
+Advisement: The integration with the permissions API's {{Permissions/query()}} method is not yet implemented in Chrome.
+
 <div algorithm>
 The <dfn method for=FileSystemHandle>queryPermission(|descriptor|)</dfn> method, when invoked, must run these steps:
 
 1. Let |result| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
-  1. [=/Resolve=] |result| with the result of running
-     <b>[=this=]</b>'s [=FileSystemHandle/entry=]'s [=query permission steps=]
-     given |descriptor| and <b>[=this=]</b>'s [=relevant settings object=].
+  1. Let |state| be the result of [=querying file system permission=]
+     given <b>[=this=]</b> and |descriptor|.{{FileSystemHandlePermissionDescriptor/mode}}.
+  1. [=/Resolve=] |result| with |state|.
 1. Return |result|.
 
 </div>
@@ -306,14 +348,14 @@ The <dfn method for=FileSystemHandle>queryPermission(|descriptor|)</dfn> method,
 ### The {{FileSystemHandle/requestPermission()}} method ### {#api-filesystemhandle-requestpermission}
 
 <div class="note domintro">
-  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/writable}} = false })
+  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} = {{"read"}} })
   : |status| = await |handle| . {{FileSystemHandle/requestPermission()}}
   :: If the state of the read permission of this handle is anything other than `"prompt"`, this
      will return that state directly. If it is `"prompt"` however, user activation is needed and
      this will show a confirmation prompt to the user. The new read permission state is then
      returned, depending on the user's response to the prompt.
 
-  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/writable}} = true })
+  : |status| = await |handle| . {{FileSystemHandle/requestPermission()|requestPermission}}({ {{FileSystemHandlePermissionDescriptor/mode}} = {{"readwrite"}} })
   :: If the state of the write permission of this handle is anything other than `"prompt"`, this
      will return that state directly. If the status of the read permission of this handle is
      `"denied"` this will return that.
@@ -328,12 +370,10 @@ The <dfn method for=FileSystemHandle>requestPermission(|descriptor|)</dfn> metho
 
 1. Let |result| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
-  1. Run <b>[=this=]</b>'s [=FileSystemHandle/entry=]'s [=request permission steps=]
-     given |descriptor| and <b>[=this=]</b>'s [=relevant settings object=].
+  1. Let |state| be the result of [=requesting file system permission=]
+     given <b>[=this=]</b> and |descriptor|.{{FileSystemHandlePermissionDescriptor/mode}}.
      If that throws an exception, [=reject=] |result| with that exception and abort.
-  1. [=/Resolve=] |result| with the result of running
-     <b>[=this=]</b>'s [=FileSystemHandle/entry=]'s [=query permission steps=]
-     given |descriptor| and <b>[=this=]</b>'s [=relevant settings object=].
+  1. [=/Resolve=] |result| with |state|.
 1. Return |result|.
 
 </div>
@@ -363,7 +403,7 @@ In Chrome 82 they are.
 ### The {{FileSystemFileHandle/getFile()}} method ### {#api-filesystemfilehandle-getfile}
 
 <div class="note domintro">
-  : |file| = await |fileHandle| . {{FileSystemFileHandle/getFile()}}
+  : <var ignore>file</var> = await |fileHandle| . {{FileSystemFileHandle/getFile()}}
   :: Returns a {{File}} representing the state on disk of the entry represented by |handle|.
      If the file on disk changes or is removed after this method is called, the returned
      {{File}} object will likely be no longer readable.
@@ -374,13 +414,11 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method, when invoked, m
 
 1. Let |result| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
-  1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
-  1. Let |permissionStatus| be the result of running
-     |entry|'s [=query permission steps=] given
-     «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `false`&nbsp;]»
-     and <b>[=this=]</b>'s [=relevant settings object=].
+  1. Let |permissionStatus| be the result of [=querying file system permission=]
+     given <b>[=this=]</b> and {{"read"}}.
   1. If |permissionStatus| is not {{PermissionState/"granted"}},
      reject |result| with a {{NotAllowedError}} and abort.
+  1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
   1. Let |f| be a new {{File}}.
   1. Set |f|'s <a spec=FileAPI>snapshot state</a> to the current state of |entry|.
   1. Set |f|'s underlying byte sequence to a copy of |entry|'s [=binary data=].
@@ -428,17 +466,12 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method,
 
 1. Let |result| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
-  1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
-  1. Run |entry|'s [=request permission steps=] given
-     «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `true`&nbsp;]»
-     and <b>[=this=]</b>'s [=relevant settings object=].
+  1. Let |permissionStatus| be the result of [=requesting file system permission=]
+     given <b>[=this=]</b> and {{"readwrite"}}.
      If that throws an exception, [=reject=] |result| with that exception and abort.
-  1. Let |permissionStatus| be the result of running
-     |entry|'s [=query permission steps=] given
-     «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `true`&nbsp;]»
-     and <b>[=this=]</b>'s [=relevant settings object=].
   1. If |permissionStatus| is not {{PermissionState/"granted"}},
      reject |result| with a {{NotAllowedError}} and abort.
+  1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
   1. Let |stream| be the result of [=create a new FileSystemWritableFileStream|creating a new FileSystemWritableFileStream=]
      for |entry| in <b>[=this=]</b>'s [=relevant realm=].
   1. If |options|.{{FileSystemCreateWritableOptions/keepExistingData}} is `true`:
@@ -510,12 +543,8 @@ support for example recursive iteration.
 The [=asynchronous iterator initialization steps=] for a {{FileSystemDirectoryHandle}} |handle|
 ant its async iterator |iterator| are:
 
-1. Let |entry| be |handle|'s [=FileSystemHandle/entry=].
-
-1. Let |permissionStatus| be the result of running
-   |entry|'s [=query permission steps=] given
-   «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `false`&nbsp;]»
-   and <b>[=this=]</b>'s [=relevant settings object=].
+1. Let |permissionStatus| be the result of [=querying file system permission=]
+   given |handle| and {{"read"}}.
 
 1. If |permissionStatus| is not {{PermissionState/"granted"}},
    throw a {{NotAllowedError}}.
@@ -532,10 +561,8 @@ and its async iterator |iterator|:
 
 1. Let |directory| be |handle|'s [=FileSystemHandle/entry=].
 
-1. Let |permissionStatus| be the result of running
-   |directory|'s [=query permission steps=] given
-   «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `false`&nbsp;]»
-   and <b>[=this=]</b>'s [=relevant settings object=].
+1. Let |permissionStatus| be the result of [=querying file system permission=]
+   given |handle| and {{"read"}}.
 
 1. If |permissionStatus| is not {{PermissionState/"granted"}},
    reject |promise| with a {{NotAllowedError}} and return |promise|.
@@ -595,19 +622,12 @@ must run these steps:
 
   1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
   1. If |options|.{{FileSystemGetFileOptions/create}} is `true`:
-    1. Run |entry|'s [=request permission steps=] given
-       «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `true`&nbsp;]»
-       and <b>[=this=]</b>'s [=relevant settings object=].
+    1. Let |permissionStatus| be the result of [=requesting file system permission=]
+       given <b>[=this=]</b> and {{"readwrite"}}.
        If that throws an exception, [=reject=] |result| with that exception and abort.
-    1. Let |permissionStatus| be the result of running
-       |entry|'s [=query permission steps=] given
-       «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `true`&nbsp;]»
-       and <b>[=this=]</b>'s [=relevant settings object=].
   1. Otherwise:
-    1. Let |permissionStatus| be the result of running
-       |entry|'s [=query permission steps=] given
-       «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `false`&nbsp;]»
-       and <b>[=this=]</b>'s [=relevant settings object=].
+    1. Let |permissionStatus| be the result of [=querying file system permission=]
+       given <b>[=this=]</b> and {{"read"}}.
   1. If |permissionStatus| is not {{PermissionState/"granted"}},
      reject |result| with a {{NotAllowedError}} and abort.
 
@@ -663,19 +683,12 @@ invoked, must run these steps:
 
   1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
   1. If |options|.{{FileSystemGetDirectoryOptions/create}} is `true`:
-    1. Run |entry|'s [=request permission steps=] given
-       «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `true`&nbsp;]»
-       and <b>[=this=]</b>'s [=relevant settings object=].
+    1. Let |permissionStatus| be the result of [=requesting file system permission=]
+       given <b>[=this=]</b> and {{"readwrite"}}.
        If that throws an exception, [=reject=] |result| with that exception and abort.
-    1. Let |permissionStatus| be the result of running
-       |entry|'s [=query permission steps=] given
-       «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `true`&nbsp;]»
-       and <b>[=this=]</b>'s [=relevant settings object=].
-  1. Else:
-    1. Let |permissionStatus| be the result of running
-       |entry|'s [=query permission steps=] given
-       «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `false`&nbsp;]»
-       and <b>[=this=]</b>'s [=relevant settings object=].
+  1. Otherwise:
+    1. Let |permissionStatus| be the result of [=querying file system permission=]
+       given <b>[=this=]</b> and {{"read"}}.
   1. If |permissionStatus| is not {{PermissionState/"granted"}},
      reject |result| with a {{NotAllowedError}} and abort.
 
@@ -727,14 +740,9 @@ these steps:
   1. If |name| is not a [=valid file name=], [=/reject=] |result| with a {{TypeError}} and abort.
 
   1. Let |entry| be <b>[=this=]</b>'s [=FileSystemHandle/entry=].
-  1. Run |entry|'s [=request permission steps=] given
-     «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `true`&nbsp;]»
-     and <b>[=this=]</b>'s [=relevant settings object=].
-     If that throws an exception, [=reject=] |result| with that exception.
-  1. Let |permissionStatus| be the result of running
-     |entry|'s [=query permission steps=] given
-     «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `true`&nbsp;]»
-     and <b>[=this=]</b>'s [=relevant settings object=].
+  1. Let |permissionStatus| be the result of [=requesting file system permission=]
+     given <b>[=this=]</b> and {{"readwrite"}}.
+     If that throws an exception, [=reject=] |result| with that exception and abort.
   1. If |permissionStatus| is not {{PermissionState/"granted"}},
      reject |result| with a {{NotAllowedError}} and abort.
 
@@ -885,10 +893,9 @@ in a [=/Realm=] |realm|, perform the following steps:
 1. Let |closeAlgorithm| be the following steps:
    1. Let |closeResult| be [=a new promise=].
    1. Run the following steps [=in parallel=]:
-      1. Let |permissionStatus| be the result of running
-         |stream|.[=[[file]]=]'s [=query permission steps=] given
-         «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `true`&nbsp;]»
-         and |stream|'s [=relevant settings object=].
+      1. Let |permissionStatus| be the [=permission state=] for a {{FileSystemPermissionDescriptor}}
+         with {{FileSystemPermissionDescriptor/handle}} representing |stream|.[=[[file]]=],
+         and {{FileSystemPermissionDescriptor/mode}} = {{"readwrite"}}.
       1. If |permissionStatus| is not {{PermissionState/"granted"}},
          reject |closeResult| with a {{NotAllowedError}} and abort.
       1. Perform user agent-specific [=malware scans and safe browsing checks=].
@@ -917,10 +924,9 @@ runs these steps:
    If this throws an exception, then return [=a promise rejected with=] that exception.
 1. Let |p| be [=a new promise=].
 1. Run the following steps [=in parallel=]:
-   1. Let |permissionStatus| be the result of running
-      |stream|.[=[[file]]=]'s [=query permission steps=] given
-      «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `true`&nbsp;]»
-     and |stream|'s [=relevant settings object=].
+   1. Let |permissionStatus| be the [=permission state=] for a {{FileSystemPermissionDescriptor}}
+      with {{FileSystemPermissionDescriptor/handle}} representing |stream|.[=[[file]]=],
+      and {{FileSystemPermissionDescriptor/mode}} = {{"readwrite"}}.
    1. If |permissionStatus| is not {{PermissionState/"granted"}},
       reject |p| with a {{NotAllowedError}} and abort.
    1. Let |command| be |input|.{{WriteParams/type}} if |input| is a {{WriteParams}},
@@ -1124,74 +1130,17 @@ Starting in Chrome 85 these new methods will also become available.
 
 ## Native File System Permissions ## {#native-file-system-permissions}
 
-<div algorithm>
-The <dfn>native file system query permission steps</dfn> for an [=/entry=] |entry|
-given a {{FileSystemHandlePermissionDescriptor}} |descriptor|
-and an [=environment settings object=] |settings| are:
-
-1. If |descriptor|.{{FileSystemHandlePermissionDescriptor/writable}} is true:
-   1. Let |readState| be the result of running the [=query permission steps=] for |entry|
-      given «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `false`&nbsp;]»
-      and |settings|.
-   1. If |readState| is not {{PermissionState/"granted"}}, return |readState|.
-1. If there was a previous invocation of this algorithm for the same |entry|, |descriptor|
-   and |settings|, returning |previousResult|, and the UA has not received
-   [=new information about the user's intent=] since that invocation, return |previousResult|.
-1. Return whichever of the following options most accurately reflects the user's
-   intent for the calling algorithm:
-   <dl class="switch">
-     : succeed without prompting the user
-     :: {{PermissionState/"granted"}}
-
-     : show the user a prompt to decide whether to succeed
-     :: {{PermissionState/"prompt"}}
-
-     : fail without prompting the user
-     :: {{PermissionState/"denied"}}
-   </dl>
-
-</div>
-
 The fact that the user picked the specific files returned by the [=native file system handle factories=] in a prompt
 should be treated by the user agent as the user intending to grant read access to the website
 for the returned files. As such, at the time the promise returned by one of the [=native file system handle factories=]
-resolves, the [=query permission steps=] for the returned entries
-given «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `false`&nbsp;]»
-should return {{PermissionState/"granted"}}.
+resolves, [=permission state=] for a descriptor with {{FileSystemPermissionDescriptor/handle}} set to the returned handle,
+and {{FileSystemPermissionDescriptor/mode}} set to {{"read"}}
+should be {{PermissionState/"granted"}}.
 
-Additionally for calls to {{showSaveFilePicker}
-the [=query permission steps=] for the returned entries
-given «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `true`&nbsp;]»
-should also return {{PermissionState/"granted"}}.
-
-<div algorithm>
-The <dfn>native file system request permission steps</dfn> for an [=/entry=] |entry|
-given a {{FileSystemHandlePermissionDescriptor}} |descriptor|
-and an [=environment settings object=] |settings| are:
-
-1. Let |status| be the result of running the [=query permission steps=] for |entry| given |descriptor| and |settings|.
-1. If |status| is not {{PermissionState/"prompt"}} return.
-1. Let |global| be |settings|'s [=environment settings object/global object=].
-1. If |global| is not a {{Window}},
-   return.
-
-   Issue: Should this throw instead of returning silently?
-
-1. If |global| does not have [=transient activation=], throw a {{NotAllowedError}}.
-1. If |settings|'s [=environment settings object/origin=] is not [=same origin=] with |settings|'s [=top-level origin=],
-   throw a {{NotAllowedError}}.
-1. Display a prompt to the user requesting access as described by |descriptor| to |entry|.
-1. Wait for the user to accept or reject the prompt.
-   The user's interaction may provide [=new information about the user's intent=]
-   for this |descriptor| and |entry|.
-   Additionally if |descriptor|.{{FileSystemHandlePermissionDescriptor/writable}} is true,
-   the user's interaction may also provide [=new information about the user's intent=] for
-   the same |entry| with «[&nbsp;"{{FileSystemHandlePermissionDescriptor/writable}}" → `false`&nbsp;]».
-
-Note: This is intentionally vague about the details of the permission UI and how the UA infers user intent.
-UAs <span class=allow-2119>should</span> be able to explore a variety of UI approaches within this framework.
-
-</div>
+Additionally for calls to {{showSaveFilePicker}}
+the [=permission state=] for a descriptor with {{FileSystemPermissionDescriptor/handle}} set to the returned handle,
+and {{FileSystemPermissionDescriptor/mode}} set to {{readwrite}}
+should be {{PermissionState/"granted"}}.
 
 <div algorithm>
 To verify that an |environment| <dfn>is allowed to show a file picker</dfn>, run these steps:
@@ -1206,9 +1155,6 @@ To verify that an |environment| <dfn>is allowed to show a file picker</dfn>, run
 1. Let |global| be |environment|'s [=environment settings object/global object=].
 
 1. If |global| does not have [=transient activation=], throw a {{SecurityError}}.
-
-   Issue: Should this be {{SecurityError}} or {{NotAllowedError}}
-   (and same question for the request permission steps checking for user activation)?
 
 </div>
 
@@ -1264,9 +1210,6 @@ these steps:
       1. At the discretion of the user agent,
          either go back to the beginning of these [=in parallel=] steps,
          or [=/reject=] |p| with an {{AbortError}} and abort.
-
-    1. Set |entry|'s [=query permission steps=] to the [=native file system query permission steps=].
-    1. Set |entry|'s [=request permission steps=] to the [=native file system request permission steps=].
 
     1. Add a new {{FileSystemFileHandle}} associated with |entry| to |result|.
 
@@ -1326,9 +1269,6 @@ these steps:
     1. At the discretion of the user agent,
        either go back to the beginning of these [=in parallel=] steps,
        or [=/reject=] |p| with an {{AbortError}} and abort.
-
-  1. Set |entry|'s [=query permission steps=] to the [=native file system query permission steps=].
-  1. Set |entry|'s [=request permission steps=] to the [=native file system request permission steps=].
 
   1. Set |entry|'s [=binary data=] to an empty [=byte sequence=].
 
@@ -1489,9 +1429,6 @@ these steps:
        either go back to the beginning of these [=in parallel=] steps,
        or [=/reject=] |p| with an {{AbortError}} and abort.
 
-  1. Set |entry|'s [=query permission steps=] to the [=native file system query permission steps=].
-  1. Set |entry|'s [=request permission steps=] to the [=native file system request permission steps=].
-
   1. Set |result| to a new {{FileSystemDirectoryHandle}} associated with |entry|.
 
   1. Perform the <a spec=html>activation notification</a> steps in |global|'s [=Window/browsing context=].
@@ -1552,8 +1489,6 @@ invoked, must run these steps:
   1. Let |dir| be a new [=directory entry=].
   1. Set |dir|'s [=entry/name=] to `""`.
   1. Set |dir|'s [=directory entry/children=] to an empty [=/set=].
-  1. Set |dir|'s [=entry/query permission steps=] to an algorithm
-     that returns {{PermissionState/"granted"}}.
   1. Set |map|["root"] to |dir|.
 
 1. Return [=a promise resolved with=] a new {{FileSystemDirectoryHandle}},

--- a/index.bs
+++ b/index.bs
@@ -157,8 +157,8 @@ permission-related algorithms and types are defined as follows:
 
   1. Let |entry| be |desc|.{{FileSystemPermissionDescriptor/handle}}'s [=FileSystemHandle/entry=].
   1. If |entry| represents an [=/entry=] in an [=origin private file system=],
-    this descriptor's [=permission state=] should always be {{PermissionState/"granted"}}.
-  1. Otherwise, if |entry|'s [=entry/parent=] is not null, this descriptor's [=permission state=] should be
+    this descriptor's [=permission state=] must always be {{PermissionState/"granted"}}.
+  1. Otherwise, if |entry|'s [=entry/parent=] is not null, this descriptor's [=permission state=] must be
     equal to the [=permission state=] for a descriptor with the same {{FileSystemPermissionDescriptor/mode}},
     and a {{FileSystemPermissionDescriptor/handle}} representing |entry|'s [=entry/parent=].
   1. Otherwise, if |desc|.{{FileSystemPermissionDescriptor/mode}} is {{"readwrite"}}:
@@ -166,7 +166,7 @@ permission-related algorithms and types are defined as follows:
       with the same {{FileSystemPermissionDescriptor/handle}},
       but {{FileSystemPermissionDescriptor/mode}} = {{"read"}}.
     1. If |read state| is not {{PermissionState/"granted"}}, this descriptor's [=permission state=]
-      should be equal to |read state|.
+      must be equal to |read state|.
 
 : [=permission request algorithm=]
 :: <div algorithm="permission request algorithm">


### PR DESCRIPTION
This is partially editorial (just changing how algorithms check
permissions), but also has a couple of normative changes:

- A change from `boolean writable` to a enum, with currently "read"
  and "readwrite" options. This is to keep open the possibility for
  write-only handles as discussed in #119.
- Changes from NotAllowedError to SecurityError in a couple of places,
  to better align with how other APIs behave.
- And of course the integration with navigator.permissions.query,
  although that is unlikely to be implemented in chrome any time soon,
  as a lot of the infra for that is missing in chrome.

This fixes #120.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/pull/200.html" title="Last updated on Jul 15, 2020, 8:45 PM UTC (315004e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/200/97ba7e6...315004e.html" title="Last updated on Jul 15, 2020, 8:45 PM UTC (315004e)">Diff</a>