### PR TITLE
Fix ReadableStream reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -15,7 +15,6 @@ Markup Shorthands: css no, markdown yes
 </pre>
 
 <pre class=link-defaults>
-spec:fetch; type:interface; text:ReadableStream
 spec:webidl; type:dfn; text:resolve
 </pre>
 


### PR DESCRIPTION
This is now only defined in the streams spec, so no need for the link-default


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/pull/201.html" title="Last updated on Jul 14, 2020, 11:23 PM UTC (9efc313)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/201/97ba7e6...9efc313.html" title="Last updated on Jul 14, 2020, 11:23 PM UTC (9efc313)">Diff</a>