### PR TITLE
Allow a single extension without having to wrap it in an array.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1089,7 +1089,7 @@ steps:
 <xmp class=idl>
 dictionary FilePickerAcceptType {
     USVString description;
-    record<USVString, sequence<USVString> or USVString> accept;
+    record<USVString, (USVString or sequence<USVString>)> accept;
 };
 
 dictionary FilePickerOptions {

--- a/index.bs
+++ b/index.bs
@@ -1089,7 +1089,7 @@ steps:
 <xmp class=idl>
 dictionary FilePickerAcceptType {
     USVString description;
-    record<USVString, sequence<USVString>> accept;
+    record<USVString, sequence<USVString> or USVString> accept;
 };
 
 dictionary FilePickerOptions {
@@ -1402,7 +1402,7 @@ const options = {
   <l>{{FilePickerOptions/types}}</l>: [
     {
       <l>{{FilePickerAcceptType/accept}}</l>: {
-        'image/svg+xml': ['svg']
+        'image/svg+xml': 'svg'
       }
     },
   ],
@@ -1431,6 +1431,8 @@ run these steps:
         1. If |parsedType|'s [=MIME type/type=] is "*", return `true`.
         1. If |parsedType|'s [=MIME type/type=] is |type|'s [=MIME type/type=], return `true`.
       1. |parsedType|'s [=MIME type/essence=] is |type|'s [=MIME type/essence=], return `true`.
+      1. If |extensions| is a string, set |extensions| to a [=list=] with a single
+        element equal to |extensions|.
       1. [=list/For each=] |extension| of |extensions|:
         1. If |filename| ends with "." followed by |extension|, return `true`.
     1. Return `false`.


### PR DESCRIPTION
Fixes #197


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/pull/207.html" title="Last updated on Jul 21, 2020, 8:23 PM UTC (f5f8776)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/native-file-system/207/e34c187...f5f8776.html" title="Last updated on Jul 21, 2020, 8:23 PM UTC (f5f8776)">Diff</a>